### PR TITLE
refactor: 메인페이지 컴포넌트들 리액트 쿼리와 의존성 제거

### DIFF
--- a/components/index/TodoList/index.test.tsx
+++ b/components/index/TodoList/index.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+
+import TodoList from '.';
+import { Todo } from '@/shared/types/todo';
+
+const todos: Todo[] = [
+  {
+    _id: '1',
+    title: 'Todo 1',
+  },
+  {
+    _id: '2',
+    title: 'Todo 2',
+  },
+];
+
+describe('<TodoList />', () => {
+  it('렌더링시에 todo 목록을 보여줘야한다.', () => {
+    render(
+      <TodoList
+        todos={todos}
+        onUpdateTodo={function ({ id, title }: { id: string; title: string }): void {
+          throw new Error('Function not implemented.');
+        }}
+        onDeleteTodo={function (id: string): void {
+          throw new Error('Function not implemented.');
+        }}
+      />
+    );
+
+    const todo1 = screen.getByText('Todo 1');
+    const todo2 = screen.getByText('Todo 2');
+
+    expect(todo1).toBeInTheDocument();
+    expect(todo2).toBeInTheDocument();
+  });
+});

--- a/components/index/TodoList/index.tsx
+++ b/components/index/TodoList/index.tsx
@@ -1,20 +1,15 @@
-import { useQuery } from 'react-query';
-
 import { Container } from './styles';
 import { Todo } from '@/shared/types/todo';
-import { findAllTodos } from '@/shared/api/todoApi';
 import TodoListItem from '@/components/index/TodoListItem';
 
-const TodoList: React.FC = () => {
-  const { data: todoList, isLoading } = useQuery('todoList', findAllTodos);
+interface TodoListProps {
+  todos: Todo[];
+}
 
-  if (isLoading) {
-    return <div>Loading...</div>;
-  }
-
+const TodoList: React.FC<TodoListProps> = ({ todos = [] }) => {
   return (
     <Container>
-      {todoList?.map((todo: Todo) => (
+      {todos?.map((todo: Todo) => (
         <TodoListItem key={todo._id} todo={todo} />
       ))}
     </Container>

--- a/components/index/TodoList/index.tsx
+++ b/components/index/TodoList/index.tsx
@@ -4,13 +4,15 @@ import TodoListItem from '@/components/index/TodoListItem';
 
 interface TodoListProps {
   todos: Todo[];
+  onUpdateTodo: ({ id, title }: { id: string; title: string }) => void;
+  onDeleteTodo: (id: string) => void;
 }
 
-const TodoList: React.FC<TodoListProps> = ({ todos = [] }) => {
+const TodoList: React.FC<TodoListProps> = ({ todos, onDeleteTodo, onUpdateTodo }) => {
   return (
     <Container>
       {todos?.map((todo: Todo) => (
-        <TodoListItem key={todo._id} todo={todo} />
+        <TodoListItem key={todo._id} todo={todo} onDeleteTodo={onDeleteTodo} onUpdateTodo={onUpdateTodo} />
       ))}
     </Container>
   );

--- a/components/index/TodoListItem/index.tsx
+++ b/components/index/TodoListItem/index.tsx
@@ -1,59 +1,31 @@
-import { useMutation, useQueryClient } from 'react-query';
-import { useState, useRef, useCallback } from 'react';
+import React, { useState } from 'react';
 
 import { Container, DeleteButton, Title } from './styles';
 import { Todo } from '@/shared/types/todo';
-import { deleteTodo, updateTodo } from '@/shared/api/todoApi';
 
 interface TodoListItemProps {
   todo: Todo;
+  onDeleteTodo: (id: string) => void;
+  onUpdateTodo: ({ id, title }: { id: string; title: string }) => void;
 }
 
-const TodoListItem: React.FC<TodoListItemProps> = ({ todo }) => {
+const TodoListItem: React.FC<TodoListItemProps> = ({ todo, onDeleteTodo, onUpdateTodo }) => {
   const [focused, setFocused] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const queryClient = useQueryClient();
-  const deleteTodoMutation = useMutation(deleteTodo, {
-    onSuccess: () => {
-      queryClient.invalidateQueries('todoList');
-    },
-    onError: () => {
-      alert('todo 삭제 실패');
-    },
-  });
-
-  const updateTodoMutation = useMutation(updateTodo, {
-    onSuccess: () => {
-      queryClient.invalidateQueries('todoList');
-    },
-    onError: () => {
-      alert('todo 업데이트 실패');
-    },
-  });
-
-  const onSubmit = useCallback(async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    const title = inputRef.current?.value;
-    if (!title) return;
-
-    updateTodoMutation.mutate({ id: todo._id, title });
-    setFocused(false);
-  }, []);
 
   return (
     <Container>
       {focused ? (
-        <form onSubmit={onSubmit} onBlur={onSubmit}>
-          <input type="text" defaultValue={todo.title} ref={inputRef} />
-        </form>
+        <input
+          type="text"
+          value={todo.title}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => onUpdateTodo({ id: todo._id, title: e.target.value })}
+        />
       ) : (
         <Title onClick={() => setFocused(true)}>{todo.title}</Title>
       )}
-      <DeleteButton onClick={() => deleteTodoMutation.mutate(todo._id)}>삭제</DeleteButton>
+      <DeleteButton onClick={() => onDeleteTodo(todo._id)}>삭제</DeleteButton>
     </Container>
   );
 };
 
-export default TodoListItem;
+export default React.memo(TodoListItem);

--- a/components/index/TodoSubmitForm/index.tsx
+++ b/components/index/TodoSubmitForm/index.tsx
@@ -1,36 +1,15 @@
-import { useCallback, useEffect, useRef } from 'react';
-import { useMutation, useQueryClient } from 'react-query';
-
 import { Form, SubmitButton, TodoInput } from './styles';
-import { createTodo } from '@/shared/api/todoApi';
 
-const TodoSubmitForm: React.FC = () => {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const queryClient = useQueryClient();
-  const addTodoMutation = useMutation(createTodo, {
-    onSuccess: () => {
-      queryClient.invalidateQueries('todoList');
-    },
-    onError: () => {
-      alert('todo 생성 실패');
-    },
-  });
+interface TodoSubmitFormProps {
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onChangeInput: (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
+  inputValue: string;
+}
 
-  useEffect(() => inputRef.current?.focus(), []);
-
-  const onSubmit = useCallback(async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    const title = inputRef.current?.value;
-    if (!title) return;
-
-    addTodoMutation.mutate(title);
-    inputRef.current.value = '';
-  }, []);
-
+const TodoSubmitForm: React.FC<TodoSubmitFormProps> = ({ onSubmit, onChangeInput, inputValue }) => {
   return (
     <Form onSubmit={onSubmit}>
-      <TodoInput ref={inputRef} />
+      <TodoInput onChange={onChangeInput} value={inputValue} />
       <SubmitButton type="submit">Add</SubmitButton>
     </Form>
   );

--- a/hooks/apis/todo/useTodoMutation.ts
+++ b/hooks/apis/todo/useTodoMutation.ts
@@ -1,0 +1,31 @@
+import { AxiosError } from 'axios';
+import { useMutation } from 'react-query';
+
+import { TodoSuccessResponse } from '@/shared/types/todo';
+import { queryClient } from '@/shared/utils/queryClient';
+import todoService from '@/services/apis/todo';
+
+export const useCreateTodoMutation = () =>
+  useMutation<TodoSuccessResponse, AxiosError, string>((title: string) => todoService.createTodo(title), {
+    onSuccess: () => {
+      queryClient.invalidateQueries('todoList');
+    },
+    onError: (error) => {
+      // TODO 콘솔에 에러 없애기
+      console.log(error);
+    },
+  });
+
+export const useUpdateTodoMutation = () =>
+  useMutation(({ id, title }: { id: string; title: string }) => todoService.updateTodo({ id, title }), {
+    onSuccess: () => {
+      queryClient.invalidateQueries('todoList');
+    },
+  });
+
+export const useDeleteTodoMutation = () =>
+  useMutation((id: string) => todoService.deleteTodo(id), {
+    onSuccess: () => {
+      queryClient.invalidateQueries('todoList');
+    },
+  });

--- a/hooks/useInput.ts
+++ b/hooks/useInput.ts
@@ -1,0 +1,19 @@
+import { useState, useCallback, ChangeEvent } from 'react';
+
+type onChangeType = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
+
+export const useInput = (initialValue = '') => {
+  const [value, setValue] = useState(initialValue);
+
+  const handler: onChangeType = useCallback(({ target }) => {
+    const max = Number(target.getAttribute('maxlength'));
+
+    if (max && target.value.length > max) {
+      target.value = target.value.slice(0, max);
+    }
+
+    setValue(target.value);
+  }, []);
+
+  return [value, handler, setValue] as [string, onChangeType, typeof setValue];
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,9 +12,12 @@ const customJestConfig = {
   moduleNameMapper: {
     '@/components/(.*)': '<rootDir>/components/$1',
     '@/shared/(.*)': '<rootDir>/shared/$1',
+    '@/services/(.*)': '<rootDir>/services/$1',
     '@/pages/(.*)': '<rootDir>/pages/$1',
     '@/store/(.*)': '<rootDir>/store/$1',
     '@/tests/(.*)': '<rootDir>/tests/$1',
+    '@/utils/(.*)': '<rootDir>/utils/$1',
+    '@/hooks/(.*)': '<rootDir>/hooks/$1',
   },
   verbose: true,
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,18 +1,22 @@
 import { NextPage } from 'next';
+import { useQuery } from 'react-query';
 import styled from 'styled-components';
 
 import Header from '@/components/index/Header';
 import SideBar from '@/components/common/Sidebar';
 import TodoList from '@/components/index/TodoList';
 import TodoSubmitForm from '@/components/index/TodoSubmitForm';
+import { findAllTodos } from '@/shared/api/todoApi';
 
 const Home: NextPage = () => {
+  const { data: todos } = useQuery('todoList', findAllTodos);
+
   return (
     <Container>
       <SideBar />
       <Content>
         <Header />
-        <TodoList />
+        <TodoList todos={todos} />
         <TodoSubmitForm />
       </Content>
     </Container>

--- a/services/apis/todo.ts
+++ b/services/apis/todo.ts
@@ -1,0 +1,11 @@
+import { Todo } from '@/shared/types/todo';
+import fetcher from '@/utils/fetcher';
+
+const todoService = {
+  createTodo: async (title: string) => await fetcher('post', '/todos', { title }),
+  getTodos: async (): Promise<Todo[]> => await fetcher('get', '/todos'),
+  updateTodo: async ({ id, title }: { id: string; title: string }) => await fetcher('patch', '/todos', { id, title }),
+  deleteTodo: async (id: string) => await fetcher('delete', `/todos/${id}`),
+};
+
+export default todoService;

--- a/shared/types/todo.ts
+++ b/shared/types/todo.ts
@@ -2,3 +2,8 @@ export interface Todo {
   _id: string;
   title: string;
 }
+
+export interface TodoSuccessResponse {
+  _id: string;
+  title: string;
+}

--- a/utils/fetcher.ts
+++ b/utils/fetcher.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+axios.defaults.baseURL = process.env.NODE_ENV === 'development' ? 'http://localhost:3001/api/v1' : '';
+
+const fetcher = async (method: 'get' | 'post' | 'patch' | 'delete', url: string, ...rest: object[]) => {
+  try {
+    const { data } = await axios[method](url, ...rest);
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      throw error;
+    }
+
+    throw new Error('different error than axios');
+  }
+};
+
+export default fetcher;


### PR DESCRIPTION
### 개요 

리액트 쿼리와 컴포넌트가 의존 관계가 생기면 컴포넌트를 테스트하기 어려워집니다. 또한 개별 컴포넌트가 요청을 보내는 로직과 연관된다는 것 자체가 스토리북을 만드는 것 또한 어렵게 합니다. 

컴포넌트는 컴포넌트스러워야합니다. 컴포넌트에 api 요청 코드를 분리함으로써 컴포넌트를 컴포넌트 답게(테스트, storybook이 용이) 사용할 수 있습니다.