### PR TITLE
fix:  SideBar 넓이가 바뀔 때마다 styled-component에 의해 클래스 추가되는 버그 수정

### DIFF
--- a/components/common/Sidebar/index.tsx
+++ b/components/common/Sidebar/index.tsx
@@ -45,7 +45,7 @@ const SideBar: React.FC<SideBarProps> = ({ onClose }) => {
   });
 
   return (
-    <Container tabIndex={0} width={width}>
+    <Container tabIndex={0} style={{ width }}>
       <SideBarContents>
         <SideBarMenuContainer>
           {menuList.map((menu: Menu, index: number) => (

--- a/components/common/Sidebar/styles.tsx
+++ b/components/common/Sidebar/styles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const Container = styled.section<{ width: number }>`
+export const Container = styled.div`
   position: relative;
   height: 100vh;
   background-color: #f7f6f3;
@@ -12,7 +12,6 @@ export const Container = styled.section<{ width: number }>`
   pointer-events: none;
   user-select: none;
 
-  width: ${({ width }) => width / 10}rem;
   // ! 최대 너비를 제한하는 코드
   /* max-width: 48rem; */
   /* min-width: 19rem; */


### PR DESCRIPTION
### 개요 #99 

 sidebar 넓이가 바뀔 때마다 styled-component에 의해 클래스 추가되는 버그 수정

### 작업 사항

- [x] sidebar width 인라인 속성으로 바꿈.

### 변경후


https://user-images.githubusercontent.com/63354527/181566238-5ba78e49-9ce3-45e0-acdf-9551a427c3b5.mov



### 기타

원래 경고로 떴던 attrs로는 해결 할 수 없었습니다. styled-component가 클래스를 자꾸 추가해주는건 attrs가 해결해주진 못했습니다.

그래서 width속성을 인라인 style로 바꿨습니다. 