### PR TITLE
feature: 주기적으로 근접 장소 확인 및 알림

### DIFF
--- a/components/index/TodoListItem/index.tsx
+++ b/components/index/TodoListItem/index.tsx
@@ -24,7 +24,6 @@ const TodoListItem: React.FC<TodoListItemProps> = ({ todo, onDeleteTodo, onUpdat
   return (
     <Container>
       <input
-        autoFocus
         type="text"
         ref={inputRef}
         placeholder="New Todo"

--- a/hooks/location/useLocation.ts
+++ b/hooks/location/useLocation.ts
@@ -1,15 +1,10 @@
 import { useCallback, useState, useEffect } from 'react';
 
 import { getCurrentPosition } from '@/shared/utils/getCurrentPosition';
+import { Location } from '@/shared/types/location';
 
 export const useLocation = () => {
-  const [myLocation, setMyLocation] = useState<
-    | {
-        latitude: number;
-        longitude: number;
-      }
-    | string
-  >('');
+  const [myLocation, setMyLocation] = useState<Location | string>('');
 
   useEffect(() => {
     if (navigator.geolocation) {

--- a/hooks/location/useLocationRef.ts
+++ b/hooks/location/useLocationRef.ts
@@ -1,0 +1,21 @@
+import { useRef, useEffect, useCallback } from 'react';
+
+import { getCurrentPositionRef } from '@/shared/utils/getCurrentPosition';
+import { Location } from '@/shared/types/location';
+
+export const useLocationRef = () => {
+  const myLocationRef = useRef<Location>({ latitude: 37.4862618, longitude: 127.1222903 });
+
+  useEffect(() => {
+    if (navigator.geolocation) {
+      getCurrentPositionRef(myLocationRef);
+    }
+  }, []);
+
+  const updateCurrentPosition = useCallback(() => {
+    if (!myLocationRef.current) return;
+    getCurrentPositionRef(myLocationRef);
+  }, []);
+
+  return { myLocationRef, updateCurrentPosition };
+};

--- a/hooks/useLocation.ts
+++ b/hooks/useLocation.ts
@@ -1,0 +1,28 @@
+import { useCallback, useState, useEffect } from 'react';
+
+import { getCurrentPosition } from '@/shared/utils/getCurrentPosition';
+
+export const useLocation = () => {
+  const [myLocation, setMyLocation] = useState<
+    | {
+        latitude: number;
+        longitude: number;
+      }
+    | string
+  >('');
+
+  useEffect(() => {
+    if (navigator.geolocation) {
+      getCurrentPosition(setMyLocation);
+    } else {
+      window.alert('현재 위치를 알 수 없어 기본 위치로 지정합니다.');
+      setMyLocation({ latitude: 37.4862618, longitude: 127.1222903 });
+    }
+  }, []);
+
+  const updateCurrentPosition = useCallback(() => {
+    getCurrentPosition(setMyLocation);
+  }, []);
+
+  return { myLocation, setMyLocation, updateCurrentPosition };
+};

--- a/hooks/useMap.ts
+++ b/hooks/useMap.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useLocation } from './useLocation';
+import { useLocation } from '@/hooks/location/useLocation';
 
 export const useMap = () => {
   const mapRef = useRef<HTMLDivElement>(null);

--- a/hooks/useMap.ts
+++ b/hooks/useMap.ts
@@ -1,24 +1,9 @@
-import { getCurrentPosition } from '@/shared/utils/getCurrentPosition';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
+import { useLocation } from './useLocation';
 
 export const useMap = () => {
   const mapRef = useRef<HTMLDivElement>(null);
-  const [myLocation, setMyLocation] = useState<
-    | {
-        latitude: number;
-        longitude: number;
-      }
-    | string
-  >('');
-
-  useEffect(() => {
-    if (navigator.geolocation) {
-      getCurrentPosition(setMyLocation);
-    } else {
-      window.alert('현재 위치를 알 수 없어 기본 위치로 지정합니다.');
-      setMyLocation({ latitude: 37.4862618, longitude: 127.1222903 });
-    }
-  }, []);
+  const { myLocation } = useLocation();
 
   useEffect(() => {
     if (typeof myLocation !== 'string') {
@@ -46,6 +31,5 @@ export const useMap = () => {
   return {
     mapRef,
     myLocation,
-    setMyLocation,
   };
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,13 +1,59 @@
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
+import { useEffect } from 'react';
 import { QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { RecoilRoot } from 'recoil';
 
 import { GlobalStyle } from 'styles/globalStyle';
 import { queryClient } from '@/shared/utils/queryClient';
+import { Location } from '@/shared/types/location';
+import { useLocationRef } from '@/hooks/location/useLocationRef';
+import { getDistance } from '@/shared/utils/getDistance';
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const { myLocationRef, updateCurrentPosition } = useLocationRef();
+
+  const alarmQueue = [{ latitude: 36.36777, longitude: 127.34149999 }];
+  const waitingQueue: Array<Location> = [];
+
+  const alarmHandler = () => {
+    if (!myLocationRef.current) return;
+    alarmQueue.forEach((location: Location, index: number) => {
+      console.log(
+        getDistance(
+          myLocationRef.current.latitude,
+          myLocationRef.current.longitude,
+          location.latitude,
+          location.longitude
+        )
+      );
+      if (
+        getDistance(
+          myLocationRef.current.latitude,
+          myLocationRef.current.longitude,
+          location.latitude,
+          location.longitude
+        ) < 100000 //100 km 설정
+      ) {
+        new Notification(`${location.latitude} : ${location.longitude}`);
+        const alarmLocation = alarmQueue.splice(index, 1);
+        waitingQueue.push(alarmLocation[0]);
+      }
+    });
+    console.log('now: ', myLocationRef.current.latitude, myLocationRef.current.longitude);
+    console.log('alarm: ', alarmQueue);
+    console.log('wait: ', waitingQueue);
+    updateCurrentPosition();
+  };
+
+  useEffect(() => {
+    const c = setInterval(alarmHandler, 1000);
+    return () => {
+      clearInterval(c);
+    };
+  }, []);
+
   return (
     <>
       <Head>

--- a/pages/map/index.tsx
+++ b/pages/map/index.tsx
@@ -6,7 +6,7 @@ import { useMap } from '@/hooks/useMap';
 import Head from 'next/head';
 
 const Map: NextPage = () => {
-  const { mapRef, myLocation, setMyLocation } = useMap();
+  const { mapRef } = useMap();
 
   return (
     <>

--- a/shared/types/location.ts
+++ b/shared/types/location.ts
@@ -1,0 +1,4 @@
+export interface Location {
+  latitude: number;
+  longitude: number;
+}

--- a/shared/utils/getCurrentPosition.ts
+++ b/shared/utils/getCurrentPosition.ts
@@ -1,19 +1,17 @@
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, MutableRefObject, SetStateAction } from 'react';
 
-export const getCurrentPosition = (
-  callback: Dispatch<
-    SetStateAction<
-      | string
-      | {
-          latitude: number;
-          longitude: number;
-        }
-    >
-  >
-) =>
+import { Location } from '../types/location';
+
+export const getCurrentPosition = (callback: Dispatch<SetStateAction<string | Location>>) =>
   navigator.geolocation.getCurrentPosition((position: GeolocationPosition) => {
     callback({
       latitude: position.coords.latitude,
       longitude: position.coords.longitude,
     });
+  });
+
+export const getCurrentPositionRef = (locationRef: MutableRefObject<Location>) =>
+  navigator.geolocation.getCurrentPosition((position: GeolocationPosition) => {
+    locationRef.current.latitude = position.coords.latitude;
+    locationRef.current.longitude = position.coords.longitude;
   });

--- a/shared/utils/getDistance.ts
+++ b/shared/utils/getDistance.ts
@@ -1,0 +1,18 @@
+export const getDistance = (lat1: number, lon1: number, lat2: number, lon2: number) => {
+  if (lat1 == lat2 && lon1 == lon2) return 0;
+
+  const radLat1 = (Math.PI * lat1) / 180;
+  const radLat2 = (Math.PI * lat2) / 180;
+  const theta = lon1 - lon2;
+  const radTheta = (Math.PI * theta) / 180;
+  let dist = Math.sin(radLat1) * Math.sin(radLat2) + Math.cos(radLat1) * Math.cos(radLat2) * Math.cos(radTheta);
+  if (dist > 1) dist = 1;
+
+  dist = Math.acos(dist);
+  dist = (dist * 180) / Math.PI;
+  dist = dist * 60 * 1.1515 * 1.609344 * 1000;
+  if (dist < 100) dist = Math.round(dist / 10) * 10;
+  else dist = Math.round(dist / 100) * 100;
+
+  return dist;
+};


### PR DESCRIPTION
### 주기적으로 근접 장소 확인 및 알림 (#93)

<!-- - 업무에 대한 설명
- 연관된 이슈 -->

### 작업 사항

- 사용자 근접 위치 확인 MOZI-82
-  알림 표시 MOZI-117

### 변경후

<!-- 변경 후 작동 화면 캡쳐 or 동영상 -->

https://user-images.githubusercontent.com/51700274/181914123-9f87cb7d-8b57-46cd-be8f-1228a585e912.mov




### 기타

일단은 _App 내부에 배열을 둬서 해당 부분으로 등록된 알람을 확인한다고 가정하고 구현해놨습니다.
추후에 indexedDB나 서버의 데이터와 비교하는 로직을 추가할 예정입니다.

_app에서 현재 사용자의 위치를 상태로 관리하면 매번 현재위치를 다시 받아올 때마다 모든 페이지가 렌더링이 다시 되어서 Ref를 사용하는 방식으로 진행하였습니다.