### PR TITLE
feat: useOnClickOutside

### DIFF
--- a/hooks/useOnClickOutside/index.test.ts
+++ b/hooks/useOnClickOutside/index.test.ts
@@ -1,0 +1,69 @@
+import { renderHook, act } from '@testing-library/react';
+import { useOnOutsideClick } from '.';
+
+const triggerRef = (value = false) => {
+  const ref = { current: null };
+
+  Object.defineProperty(ref, 'current', {
+    get: jest.fn(() => (value ? document.createElement('div') : null)),
+    set: jest.fn(() => null),
+  });
+
+  return ref;
+};
+
+describe('useOnClickOutside', () => {
+  it('ref가 있다면 document에 이벤트 리스너를 달아야한다.', () => {
+    const ref = triggerRef(true);
+    const handler = jest.fn();
+
+    renderHook(() => useOnOutsideClick(ref, handler));
+
+    act(() => {
+      document.dispatchEvent(new Event('mousedown'));
+      document.dispatchEvent(new Event('touchstart'));
+    });
+
+    expect(handler).toHaveBeenCalledTimes(2); // mousedown, touchstart
+  });
+
+  it('ref가 없다면 document에 이벤트 리스너를 달지 않아야한다.', () => {
+    const ref = triggerRef(false);
+    const handler = jest.fn();
+
+    renderHook(() => useOnOutsideClick(ref, handler));
+
+    act(() => {
+      document.dispatchEvent(new Event('mousedown'));
+      document.dispatchEvent(new Event('touchstart'));
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('ref 바깥을 클릭했을 때 handler가 호출되어야 한다.', () => {
+    const handler = jest.fn();
+    const ref = triggerRef(true);
+
+    renderHook(() => useOnOutsideClick(ref, handler));
+
+    act(() => {
+      document.dispatchEvent(new Event('mousedown'));
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('ref 바깥을 터치했을 때 handler가 호출되어야 한다.', () => {
+    const handler = jest.fn();
+    const ref = triggerRef(true);
+
+    renderHook(() => useOnOutsideClick(ref, handler));
+
+    act(() => {
+      document.dispatchEvent(new Event('touchstart'));
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hooks/useOnClickOutside/index.ts
+++ b/hooks/useOnClickOutside/index.ts
@@ -1,0 +1,21 @@
+import { RefObject, useEffect } from 'react';
+
+type Handler = (event: MouseEvent | TouchEvent) => void;
+
+export const useOnOutsideClick = <T extends HTMLElement = HTMLElement>(ref: RefObject<T>, handler: Handler) => {
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (!ref.current || ref.current.contains(event.target as HTMLElement)) return;
+
+      handler(event);
+    };
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]);
+};


### PR DESCRIPTION
### 개요 

프로젝트를 진행하면서 해당 컴포넌트 바깥쪽이 클릭되거나 터치되어야 할 상황에 이 훅을 활용할 수 있습니다.

이름을 어떻게 지을까 하면서 다른 사람들이 지어놓은 이름을 참고했는데 `useOnClickOutside`가 적당한 것 같습니다.

ref에 관찰할 대상을 전달하고 ref 바깥쪽의 다른 것을 클릭하면 그 클릭을 감지하고 두번째 인자로 전달한 handler가 실행됩니다. 

```ts
import { RefObject, useEffect } from 'react';

type Handler = (event: MouseEvent | TouchEvent) => void;

export const useOnOutsideClick = <T extends HTMLElement = HTMLElement>(ref: RefObject<T>, handler: Handler) => {
  useEffect(() => {
    const listener = (event: MouseEvent | TouchEvent) => {
      if (!ref.current || ref.current.contains(event.target as HTMLElement)) return;

      handler(event);
    };

    document.addEventListener('mousedown', listener);
    document.addEventListener('touchstart', listener);

    return () => {
      document.removeEventListener('mousedown', listener);
      document.removeEventListener('touchstart', listener);
    };
  }, [ref, handler]);
};

```



### 작업 사항

- [x] useOnClickOutside test code
- [x] useOnClickOutside 





