### PR TITLE
refactor: TodoListItem

### DIFF
--- a/components/index/TodoList/index.test.tsx
+++ b/components/index/TodoList/index.test.tsx
@@ -5,11 +5,11 @@ import { Todo } from '@/shared/types/todo';
 
 const todos: Todo[] = [
   {
-    _id: '1',
+    id: '1',
     title: 'Todo 1',
   },
   {
-    _id: '2',
+    id: '2',
     title: 'Todo 2',
   },
 ];

--- a/components/index/TodoList/index.tsx
+++ b/components/index/TodoList/index.tsx
@@ -4,15 +4,15 @@ import TodoListItem from '@/components/index/TodoListItem';
 
 interface TodoListProps {
   todos: Todo[];
-  onUpdateTodo: ({ id, title }: { id: string; title: string }) => void;
   onDeleteTodo: (id: string) => void;
+  onUpdateTodo: ({ id, title, description }: { id: string; title?: string; description?: string }) => void;
 }
 
 const TodoList: React.FC<TodoListProps> = ({ todos, onDeleteTodo, onUpdateTodo }) => {
   return (
     <Container>
       {todos?.map((todo: Todo) => (
-        <TodoListItem key={todo._id} todo={todo} onDeleteTodo={onDeleteTodo} onUpdateTodo={onUpdateTodo} />
+        <TodoListItem key={todo.id} todo={todo} onDeleteTodo={onDeleteTodo} onUpdateTodo={onUpdateTodo} />
       ))}
     </Container>
   );

--- a/components/index/TodoListItem/index.stories.tsx
+++ b/components/index/TodoListItem/index.stories.tsx
@@ -9,7 +9,7 @@ export default {
 } as ComponentMeta<typeof TodoListItem>;
 
 const todo: Todo = {
-  _id: '1',
+  id: '1',
   title: 'Todo 1',
 };
 

--- a/components/index/TodoListItem/index.test.tsx
+++ b/components/index/TodoListItem/index.test.tsx
@@ -4,7 +4,7 @@ import { Todo } from '@/shared/types/todo';
 import TodoListItem from '.';
 
 const todo: Todo = {
-  _id: '1',
+  id: '1',
   title: 'Todo 1',
 };
 
@@ -19,7 +19,7 @@ describe('<TodoListItem />', () => {
     expect(todoItem).toBeInTheDocument();
   });
 
-  it('DeleteButton', () => {
+  it('Delete Todo', () => {
     render(<TodoListItem todo={todo} onDeleteTodo={onDelete} onUpdateTodo={onUpdate} />);
 
     const button = screen.getByText('삭제');
@@ -28,7 +28,7 @@ describe('<TodoListItem />', () => {
     expect(onDelete).toHaveBeenCalledTimes(1);
   });
 
-  it('UpdateButton', () => {
+  it('Update Title', () => {
     render(<TodoListItem todo={todo} onDeleteTodo={onDelete} onUpdateTodo={onUpdate} />);
 
     const input = screen.getByDisplayValue('Todo 1');

--- a/components/index/TodoListItem/index.tsx
+++ b/components/index/TodoListItem/index.tsx
@@ -19,20 +19,17 @@ import {
 interface TodoListItemProps {
   todo: Todo;
   onDeleteTodo: (id: string) => void;
-  onUpdateTodo: ({ id, title }: { id: string; title: string }) => void;
+  onUpdateTodo: ({ id, title, description }: { id: string; title?: string; description?: string }) => void;
 }
 
 const TodoListItem: React.FC<TodoListItemProps> = ({ todo, onDeleteTodo, onUpdateTodo }) => {
+  const [title, setTitle] = useState<string>(todo.title);
+  const [description, setDescription] = useState<string | undefined>(todo.description);
   const [checked, setChecked] = useState(false);
   const [isDoubleClicked, setIsDoubleClicked] = useState(false);
   const [isModal, setIsModal] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-
-  // todolistItem의 상태이다. -> todo title, description ,location
-  // const [title, setTitle] = useState(todo.title);
-  // const [description, setDescription] = useState(todo.description);
-  // const [location, setLocation] = useState(todo.location);
 
   const onClickOutsideHandler = useCallback(() => {
     setIsDoubleClicked(false);
@@ -43,7 +40,8 @@ const TodoListItem: React.FC<TodoListItemProps> = ({ todo, onDeleteTodo, onUpdat
 
   const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation();
-    onUpdateTodo({ id: todo._id, title: e.target.value });
+    setTitle(e.target.value);
+    onUpdateTodo({ id: todo.id, title: e.target.value });
   }, []);
 
   const onKeyUp = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -58,24 +56,32 @@ const TodoListItem: React.FC<TodoListItemProps> = ({ todo, onDeleteTodo, onUpdat
     setIsDoubleClicked(true);
   }, []);
 
+  const onChangeDescription = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    setDescription(e.target.value);
+    if (description) onUpdateTodo({ id: todo.id, description: e.target.value });
+  }, []);
+
   return (
     <Container isDoubleClicked={isDoubleClicked} onDoubleClick={onDoubleClickHandler} ref={containerRef}>
       <TitleContainer>
         <CheckBox onClick={onCheckHandler}>{checked && <Image src="/assets/svgs/check.svg" layout="fill" />}</CheckBox>
         <Title
-          placeholder="New Todo"
-          onDoubleClick={onDoubleClickHandler}
           ref={inputRef}
+          placeholder="New Todo"
+          value={title}
           onChange={onChange}
           onKeyUp={onKeyUp}
-          defaultValue={todo.title}
+          onDoubleClick={onDoubleClickHandler}
         />
-        <DeleteButton onClick={() => onDeleteTodo(todo._id)}>삭제</DeleteButton> {/* ! 나중에 삭제 */}
+        <DeleteButton onClick={() => onDeleteTodo(todo.id)}>삭제</DeleteButton> {/* ! 나중에 삭제 */}
       </TitleContainer>
       {isDoubleClicked && (
         <>
           <DescriptionContainer>
-            <Description></Description>
+            <Description contentEditable onChange={onChangeDescription}>
+              {description || '설명을 입력해주세요'}
+            </Description>
           </DescriptionContainer>
 
           <SubTaskContainer></SubTaskContainer>

--- a/hooks/apis/todo/useTodoMutation.ts
+++ b/hooks/apis/todo/useTodoMutation.ts
@@ -17,11 +17,15 @@ export const useCreateTodoMutation = () =>
   });
 
 export const useUpdateTodoMutation = () =>
-  useMutation(({ id, title }: { id: string; title: string }) => todoService.updateTodo({ id, title }), {
-    onSuccess: () => {
-      queryClient.invalidateQueries('todoList');
-    },
-  });
+  useMutation(
+    ({ id, title, description }: { id: string; title?: string; description?: string }) =>
+      todoService.updateTodo({ id, title, description }),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries('todoList');
+      },
+    }
+  );
 
 export const useDeleteTodoMutation = () =>
   useMutation((id: string) => todoService.deleteTodo(id), {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,8 +29,8 @@ const Home: NextPage = () => {
     });
   };
 
-  const onUpdateTodo = ({ id, title }: { id: string; title: string }) => {
-    updateTodoMutation.mutate({ id, title });
+  const onUpdateTodo = ({ id, title, description }: { id: string; title?: string; description?: string }) => {
+    updateTodoMutation.mutate({ id, title, description });
   };
 
   const onDeleteTodo = (id: string) => {

--- a/services/apis/todo.ts
+++ b/services/apis/todo.ts
@@ -4,7 +4,8 @@ import fetcher from '@/shared/utils/fetcher';
 const todoService = {
   createTodo: async (title: string) => await fetcher('post', '/todos', { title }),
   getTodos: async (): Promise<Todo[]> => await fetcher('get', '/todos'),
-  updateTodo: async ({ id, title }: { id: string; title: string }) => await fetcher('patch', `/todos/${id}`, { title }),
+  updateTodo: async ({ id, title, description }: { id: string; title?: string; description?: string }) =>
+    await fetcher('patch', `/todos/${id}`, { title }),
   deleteTodo: async (id: string) => await fetcher('delete', `/todos/${id}`),
 };
 

--- a/shared/types/todo.ts
+++ b/shared/types/todo.ts
@@ -1,11 +1,11 @@
 export interface Todo {
-  _id: string;
+  id: string;
   title: string;
   description?: string;
 }
 
 export interface TodoSuccessResponse {
-  _id: string;
+  id: string;
   title: string;
   description?: string;
 }


### PR DESCRIPTION
### 개요 

- 서버의 Todo return type 수정에 따른 프론트엔드에서 Todo 타입 수정 (_id -> id)
- 토론한 결과 Todo Title, Todo Description...등 (Todo에서 사용자 입력을 받을 수 있는 모든것)을 상태로 관리

### 작업 사항

- [x] Fix Todo Type
- [x] Todo title, Todo description 상태로 관리