### PR TITLE
feat: TodoListItem Description에 ContentEditable 적용

### DIFF
--- a/components/index/TodoListItem/index.tsx
+++ b/components/index/TodoListItem/index.tsx
@@ -56,9 +56,10 @@ const TodoListItem: React.FC<TodoListItemProps> = ({ todo, onDeleteTodo, onUpdat
     setIsDoubleClicked(true);
   }, []);
 
-  const onChangeDescription = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+  const onInputDescription = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation();
-    setDescription(e.target.value);
+    setDescription(e.target.innerText);
+
     if (description) onUpdateTodo({ id: todo.id, description: e.target.value });
   }, []);
 
@@ -79,8 +80,14 @@ const TodoListItem: React.FC<TodoListItemProps> = ({ todo, onDeleteTodo, onUpdat
       {isDoubleClicked && (
         <>
           <DescriptionContainer>
-            <Description contentEditable onChange={onChangeDescription}>
-              {description || '설명을 입력해주세요'}
+            <Description
+              placeholder="Notes"
+              contentEditable
+              suppressContentEditableWarning
+              spellCheck={false}
+              onInput={onInputDescription}
+            >
+              {description}
             </Description>
           </DescriptionContainer>
 

--- a/components/index/TodoListItem/styles.tsx
+++ b/components/index/TodoListItem/styles.tsx
@@ -54,7 +54,20 @@ export const DescriptionContainer = styled.div`
   width: 100%;
 `;
 
-export const Description = styled.div``;
+export const Description = styled.div`
+  width: 100%;
+
+  margin-top: 2rem;
+  padding: 1.6rem 2.4rem;
+  border: 0.1rem solid #d6d6d6;
+  border-radius: 0.4rem;
+
+  &:empty:before {
+    content: attr(placeholder);
+    color: grey;
+    display: inline-block;
+  }
+`;
 
 export const SubTaskContainer = styled.div``;
 


### PR DESCRIPTION
### 개요 

#122 

### 작업 사항

- [x] Description에 ContentEditable 적용
- [x] 스타일로 placeholder 추가


### 변경후

<img width="1533" alt="image" src="https://user-images.githubusercontent.com/63354527/182762143-3f54058b-7665-4c25-9dd9-6f85fff08129.png">

### 참고자료
- https://stackoverflow.com/questions/49639144/why-does-react-warn-against-an-contenteditable-component-having-children-managed
- https://chaewonkong.github.io/posts/auto-width-text-input.html