### PR TITLE
fix: notification api end point update

### DIFF
--- a/services/apis/webpush.ts
+++ b/services/apis/webpush.ts
@@ -2,7 +2,7 @@ import fetcher from '@/shared/utils/fetcher';
 
 const webPushService = {
   notification: async (subscription: PushSubscription, id: string) =>
-    await fetcher('post', '/webpush', { subscription: JSON.stringify(subscription), id }),
+    await fetcher('post', `/webpush/${id}`, { subscription: JSON.stringify(subscription) }),
 };
 
 export default webPushService;


### PR DESCRIPTION
### 개요 (MOZI-152)

api를 `POST .../api/v1/webpush/:id`로 바꿨기 때문에 `webpushService`도 바꿨습니다.

### 작업 사항

- api end point 변경