### PR TITLE
feat: ESC 클릭시 TodoListItem에서 포커스 제거

### DIFF
--- a/components/index/TodoListItem/index.tsx
+++ b/components/index/TodoListItem/index.tsx
@@ -52,6 +52,7 @@ const TodoListItem: React.FC<TodoListItemProps> = ({ todo, onDeleteTodo, onUpdat
 
   const onKeyUp = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') onClickOutsideHandler();
+    else if (e.key === 'Escape') onClickOutsideHandler();
   }, []);
 
   const onCheckHandler = useCallback(() => {
@@ -87,6 +88,7 @@ const TodoListItem: React.FC<TodoListItemProps> = ({ todo, onDeleteTodo, onUpdat
               contentEditable
               suppressContentEditableWarning
               onInput={onInputDescription}
+              onKeyUp={onKeyUp}
               spellCheck={false}
             >
               {todo.description}


### PR DESCRIPTION
### 개요 

esc 클릭시 title이나 description을 입력하고 있다면 포커스를 제거해준다. 
문제를 해결하기 위한 코딩을 했다. 개선의 여지는 있다. 

TodoListItem에 focus 상태를 만들어 TodoListItem이 focused 되어있다면 window에 등록된 eventListener가 처리해주는 것은 어떨까?

### 작업 사항

- [x] ESC 클릭시 onClickOutsideHandler() 실행
