### PR TITLE
chore: fix figure props

### DIFF
--- a/components/common/Figure/ARROWLEFT.tsx
+++ b/components/common/Figure/ARROWLEFT.tsx
@@ -4,8 +4,8 @@ const ARROWLEFT: React.FC = () => {
   return (
     <SvgWrap>
       <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M27 8L20 15L27 22" stroke="#2A2A2A" stroke-linecap="round" stroke-linejoin="round" />
-        <path d="M20.3809 8L13.3809 15L20.3809 22" stroke="#2A2A2A" stroke-linecap="round" stroke-linejoin="round" />
+        <path d="M27 8L20 15L27 22" stroke="#2A2A2A" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M20.3809 8L13.3809 15L20.3809 22" stroke="#2A2A2A" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
     </SvgWrap>
   );

--- a/components/common/Figure/ARROWRIGHT.tsx
+++ b/components/common/Figure/ARROWRIGHT.tsx
@@ -4,8 +4,8 @@ const ARROWRIGHT: React.FC = () => {
   return (
     <SvgWrap>
       <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M3 8L10 15L3 22" stroke="#2A2A2A" stroke-linecap="round" stroke-linejoin="round" />
-        <path d="M9.61914 8L16.6191 15L9.61914 22" stroke="#2A2A2A" stroke-linecap="round" stroke-linejoin="round" />
+        <path d="M3 8L10 15L3 22" stroke="#2A2A2A" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M9.61914 8L16.6191 15L9.61914 22" stroke="#2A2A2A" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
     </SvgWrap>
   );


### PR DESCRIPTION
### 개요 

svg의 props를 react에 맞게 바꿨습니다.



```js
<SvgWrap>
  <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
    <path d="M3 8L10 15L3 22" stroke="#2A2A2A" strokeLinecap="round" strokeLinejoin="round" />
    <path d="M9.61914 8L16.6191 15L9.61914 22" stroke="#2A2A2A" strokeLinecap="round" strokeLinejoin="round" />
  </svg>
</SvgWrap>
```