### PR TITLE
feat: NextPageLayout

### DIFF
--- a/components/common/Sidebar/index.tsx
+++ b/components/common/Sidebar/index.tsx
@@ -7,12 +7,9 @@ import { useDrag } from '@/hooks/useDrag';
 import { sideBarStateAtom } from '@/store/sidebar/atom';
 import { ARROWLEFT, ARROWRIGHT, HAMBURGER } from '@/components/common/Figure';
 import SideBarMenu from '@/components/common/Sidebar/SideBarMenu';
-import { useRouter } from 'next/router';
 
 const SideBar: React.FC = () => {
-  const router = useRouter();
   const [isSideBarOpened, setIsSideBarOpened] = useRecoilState(sideBarStateAtom);
-  const [isSideBarHidden] = useState(router.pathname === '/login' ? true : false);
   const [controlIconHovered, setControlIconHovered] = useState(false);
   const [width, setWidth] = useState(300);
 
@@ -52,7 +49,6 @@ const SideBar: React.FC = () => {
 
   return (
     <Container
-      isSideBarHidden={isSideBarHidden}
       tabIndex={0}
       style={{ width }}
       initial={{ width }}

--- a/components/common/Sidebar/styles.tsx
+++ b/components/common/Sidebar/styles.tsx
@@ -2,12 +2,12 @@ import styled from 'styled-components';
 import { motion } from 'framer-motion';
 import { media } from '@/styles/media';
 
-export const Container = styled(motion.aside)<{ isSideBarHidden?: boolean }>`
+export const Container = styled(motion.aside)`
   position: relative;
   height: 100vh;
   width: 100%;
 
-  display: ${({ isSideBarHidden }) => (isSideBarHidden ? 'none' : 'flex')};
+  display: flex;
   flex-direction: column;
   flex-shrink: 0;
   align-items: center;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,8 @@
-import type { NextPage } from 'next';
-import { useCallback, useEffect } from 'react';
+import { ReactElement, useCallback, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
+import { NextPageWithLayout } from './_app';
 import todoService from '@/services/apis/todo';
 import { useLocationRef } from '@/hooks/location/useLocationRef';
 import { Todo, TodoUpdateRequest } from '@/shared/types/todo';
@@ -12,8 +12,9 @@ import Header from '@/components/common/Header';
 import Title from '@/components/index/Title';
 import TodoList from '@/components/index/TodoList';
 import Footer from '@/components/common/Footer';
+import AppLayout from '@/components/common/AppLayout';
 
-const Home: NextPage = () => {
+const Home: NextPageWithLayout = () => {
   const [todos, setTodos] = useRecoilState(todosState);
   const { myLocationRef, updateCurrentPosition } = useLocationRef();
 
@@ -84,6 +85,10 @@ const Home: NextPage = () => {
       <Footer />
     </Container>
   );
+};
+
+Home.getLayout = function getLayout(page: ReactElement) {
+  return <AppLayout>{page}</AppLayout>;
 };
 
 const Container = styled.div`

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,15 +1,16 @@
-import { sideBarStateAtom } from '@/store/sidebar/atom';
-import { theme } from '@/styles/theme';
-import { flexCenter } from '@/styles/utils';
-import type { NextPage } from 'next';
 import { useSession } from 'next-auth/react';
-// import {signOut} from 'next-auth/react'
 import Image from 'next/image';
-import { useEffect } from 'react';
+import { ReactElement, useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 
-const Login: NextPage = () => {
+import { NextPageWithLayout } from '../_app';
+import { sideBarStateAtom } from '@/store/sidebar/atom';
+import { theme } from '@/styles/theme';
+import { flexCenter } from '@/styles/utils';
+// import {signOut} from 'next-auth/react'
+
+const Login: NextPageWithLayout = () => {
   const setIsSideBarOpen = useSetRecoilState(sideBarStateAtom);
 
   useEffect(() => {
@@ -34,6 +35,20 @@ const Login: NextPage = () => {
     </Container>
   );
 };
+
+Login.getLayout = function getLayout(page: ReactElement) {
+  return <LoginLayout>{page}</LoginLayout>;
+};
+
+const LoginLayout = styled.div`
+  position: relative;
+  display: flex;
+
+  width: 100%;
+  height: 100%;
+
+  overflow: hidden;
+`;
 
 const Container = styled.div`
   width: 100%;

--- a/pages/map/index.tsx
+++ b/pages/map/index.tsx
@@ -1,14 +1,15 @@
-import type { NextPage } from 'next';
 import Head from 'next/head';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, ReactElement } from 'react';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
+import { NextPageWithLayout } from '../_app';
 import { useNaverMap } from '@/hooks/useNaverMap';
 import { todosLocationState } from '@/store/todo/atom';
 import SearchSideBar from '@/components/map/SearchSideBar';
+import AppLayout from '@/components/common/AppLayout';
 
-const Map: NextPage = () => {
+const Map: NextPageWithLayout = () => {
   const naverMapRef = useRef<HTMLDivElement>(null);
   const todosLocation = useRecoilValue(todosLocationState);
   const { naverMap, createMarker, createPosition } = useNaverMap();
@@ -38,6 +39,10 @@ const Map: NextPage = () => {
       </Container>
     </>
   );
+};
+
+Map.getLayout = function getLayout(page: ReactElement) {
+  return <AppLayout>{page}</AppLayout>;
 };
 
 const Container = styled.div`

--- a/shared/types/environment.d.ts
+++ b/shared/types/environment.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 namespace NodeJS {
   interface ProcessEnv extends NodeJS.ProcessEnv {
     KAKAO_ID: string;


### PR DESCRIPTION
### 개요 

로그인페이지, 지도페이지는 레이아웃이 다릅니다.
예를들어 지도페이지에는 사이드바가 기본레이아웃으로 최상위 컴포넌트에서 선언해버릴 수 있지만 로그인페이지에는 사이드바를 레이아웃에 둘 필요가 없죠.

기존에는 모든 페이지가 사이드바에 대한 레이아웃을 공유해서 로그인 페이지에서 hidden 처리하는등으로 처리했는데 이제 각기 다른 레이아웃을 적용할 수 있게 했습니다.

이제 페이지별로 각기 다른 레이아웃을 활용할 수 있습니다.

아래에 Next.js Layout 공식문서 참고자료 남깁니다.

### 작업 사항

- [x] NextPageLayout
- [x] Map page layout
- [x] index page layout
- [x] login page layout

### 변경후
```ts
// login
Login.getLayout = function getLayout(page: ReactElement) {
  return <LoginLayout>{page}</LoginLayout>;
};
```

```ts
// map
Map.getLayout = function getLayout(page: ReactElement) {
  return <AppLayout>{page}</AppLayout>;
};
```
### 기타

https://nextjs.org/docs/basic-features/layouts
