### PR TITLE
fix: check를 누를 때 todolistitem이 focus되는 현상 수정

### DIFF
--- a/components/index/TodoListItem/index.tsx
+++ b/components/index/TodoListItem/index.tsx
@@ -134,7 +134,8 @@ const TodoListItem: React.FC<TodoListItemProps> = ({
     }
   }, []);
 
-  const onCheckHandler = useCallback((done: boolean) => {
+  const onCheckHandler = useCallback((e: React.MouseEvent<HTMLDivElement, MouseEvent>, done: boolean) => {
+    e.stopPropagation();
     onUpdateTodo({ id, done: !done });
   }, []);
 
@@ -173,7 +174,7 @@ const TodoListItem: React.FC<TodoListItemProps> = ({
       ref={containerRef}
     >
       <MainContainer>
-        <CheckBox onClick={() => onCheckHandler(done)} checked={done} />
+        <CheckBox onClick={(e) => onCheckHandler(e, done)} checked={done} />
         <Title
           ref={titleRef}
           placeholder="New Todo"


### PR DESCRIPTION
### 개요 MOZI-217

기존 체크박스 클릭하면 Todo Focus가 같이 되었는데  이벤트 버블링을 막음으로서 check만 하면 check만되고 같이 focus되는 현상 제거

### 작업 사항

- [x] todolistitem check 버튼시 이벤트 버블링 현상 수정
