### PR TITLE
fix: docker compose 환경변수 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
   mozi-client:
     image: hancihu/mozi-client
+    env_file:
+      - .env.local
     ports:
       - '3000:3000'
 


### PR DESCRIPTION
mozi.cz에서 환경변수(env) 설정이 안되서 오류가 나던 버그를 수정하려고 docker-compose.yml 파일을 수정하였습니다.
잘 되었으면 좋겠네요...
