### PR TITLE
feat: recoil-persist를 사용한 사이드바 상태 기억

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recoil": "^0.7.4",
+    "recoil-persist": "^4.2.0",
     "styled-components": "^5.3.5",
     "styled-reset": "^4.4.2",
     "uuid": "^9.0.0"

--- a/src/components/common/Sidebar/index.tsx
+++ b/src/components/common/Sidebar/index.tsx
@@ -1,15 +1,15 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import Image from 'next/image';
-import { useRecoilState } from 'recoil';
 
-import { Container, ArrowLeftContainer, ControlContainer, LogoContainer, Logo, SideBarResizer } from './styles';
 import { useDrag } from '@/hooks/useDrag';
-import { sideBarStateAtom } from '@/store/sidebar/atom';
-import { ARROWLEFT, ARROWRIGHT, HAMBURGER } from '@/components/common/Figure';
+import { useSideBar } from '@/hooks/useSideBar';
 import SideBarMenu from '@/components/common/Sidebar/SideBarMenu';
+import { ARROWLEFT, ARROWRIGHT, HAMBURGER } from '@/components/common/Figure';
+import { Container, ArrowLeftContainer, ControlContainer, LogoContainer, Logo, SideBarResizer } from './styles';
+import { getSideBarStateFromLocalStorage } from '@/store/localStorage/sidebar';
 
 const SideBar: React.FC = () => {
-  const [isSideBarOpened, setIsSideBarOpened] = useRecoilState(sideBarStateAtom);
+  const [isSideBarOpened, setIsSideBarOpened] = useSideBar();
   const [controlIconHovered, setControlIconHovered] = useState(false);
   const [width, setWidth] = useState(300);
 
@@ -28,6 +28,10 @@ const SideBar: React.FC = () => {
 
     setWidth(nextWidth);
   });
+
+  useEffect(() => {
+    setIsSideBarOpened(getSideBarStateFromLocalStorage());
+  }, []);
 
   const onCloseSideBar = useCallback(() => {
     setIsSideBarOpened(false);
@@ -50,16 +54,10 @@ const SideBar: React.FC = () => {
   return (
     <Container
       tabIndex={0}
-      style={{ width }}
-      initial={{ width }}
-      animate={{ width }}
-      exit={{ width: 0 }}
-      transition={
-        {
-          // type: 'spring'
-          // duration: 0,
-        }
-      }
+      style={{ width: isSideBarOpened ? width : 0 }}
+      initial={{ width: isSideBarOpened ? width : 0 }}
+      animate={{ width: isSideBarOpened ? width : 0 }}
+      // exit={{ width: isSideBarOpened ? width : 0 }}
     >
       {/* 최상단 사이드바 제어하는 부분 */}
       <ControlContainer>

--- a/src/components/map/SearchSideBar/index.tsx
+++ b/src/components/map/SearchSideBar/index.tsx
@@ -1,15 +1,13 @@
 import { useState, useCallback, Dispatch, SetStateAction, useRef, useEffect } from 'react';
-import { useRecoilState } from 'recoil';
 
 import RecentSearch from './RecentSearch';
-import { searchSideBarAtom } from '@/store/sidebar/atom';
 import { getLocationSearchResult } from '@/shared/utils/map';
 import { getCurrentPosition } from '@/shared/utils/location';
-import { SIDEBARARROWLEFT } from '@/components/common/Figure';
 import { Location, LocationSearchResult } from '@/shared/types/location';
 import { useOnClickOutside } from '@/hooks/useOnClickOutside';
 import { getItem, setItem } from '@/store/localStorage';
 import { SEARCHPLACE } from '@/components/common/Figure';
+import { SIDEBARARROWLEFT } from '@/components/common/Figure';
 import {
   Container,
   SearchContainer,
@@ -25,6 +23,7 @@ import {
   PlaceName,
   SearchTodoContainer,
 } from './styles';
+import { getSearchSideBarStateFromLocalStorage } from '@/store/localStorage/sidebar';
 
 interface SearchSideBarProps {
   // naverMap: naver.maps.Map | undefined;
@@ -36,7 +35,7 @@ interface SearchSideBarProps {
 const SearchSideBar: React.FC<SearchSideBarProps> = ({ setCoords }) => {
   const [keyword, setKeyword] = useState('');
   const [isSearching, setIsSearching] = useState(false);
-  const [isSearchBarOpen, setIsSearchBarOpen] = useRecoilState(searchSideBarAtom);
+  const [isSearchBarOpen, setIsSearchBarOpen] = useState(true);
   const [searchResult, setSearchResult] = useState<LocationSearchResult[]>([]);
   const [recentSearch, setRecentSearch] = useState<LocationSearchResult[]>([]);
 
@@ -52,6 +51,10 @@ const SearchSideBar: React.FC<SearchSideBarProps> = ({ setCoords }) => {
     if (recentSearchFromLocalStorage) {
       setRecentSearch(JSON.parse(recentSearchFromLocalStorage));
     }
+  }, []);
+
+  useEffect(() => {
+    setIsSearchBarOpen(getSearchSideBarStateFromLocalStorage());
   }, []);
 
   const clearSearch = useCallback(() => {
@@ -133,7 +136,7 @@ const SearchSideBar: React.FC<SearchSideBarProps> = ({ setCoords }) => {
 
       <RecentSearch recentSearch={recentSearch} setCoords={setCoords} />
 
-      <SideBarToggleButton type="button" onClick={() => setIsSearchBarOpen(!isSearchBarOpen)}>
+      <SideBarToggleButton type="button" onClick={() => setIsSearchBarOpen((prev) => !prev)}>
         {isSearchBarOpen ? '닫기' : '열기'}
         <IconContainer isSearchBarOpen={isSearchBarOpen}>
           <SIDEBARARROWLEFT />

--- a/src/hooks/useSearchSideBar.ts
+++ b/src/hooks/useSearchSideBar.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+
+import { searchSideBarAtom } from '@/store/sidebar/atom';
+
+export const useSearchSideBar = () => {
+  const [isInitial, setIsInitial] = useState(true);
+  const [isSearchSideBarOpened, setIsSearchSideBarOpened] = useRecoilState(searchSideBarAtom);
+
+  useEffect(() => {
+    setIsInitial(false);
+  }, []);
+
+  return [isInitial ? true : isSearchSideBarOpened, setIsSearchSideBarOpened] as const;
+};

--- a/src/hooks/useSideBar.ts
+++ b/src/hooks/useSideBar.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+
+import { sideBarStateAtom } from '@/store/sidebar/atom';
+
+export const useSideBar = () => {
+  const [isInitial, setIsInitial] = useState(true);
+  const [isSideBarOpened, setIsSideBarOpened] = useRecoilState(sideBarStateAtom);
+
+  useEffect(() => {
+    setIsInitial(false);
+  }, []);
+
+  return [isInitial ? true : isSideBarOpened, setIsSideBarOpened] as const;
+};

--- a/src/store/localStorage/sidebar.ts
+++ b/src/store/localStorage/sidebar.ts
@@ -1,0 +1,19 @@
+export const getSideBarStateFromLocalStorage = () => {
+  if (typeof window !== 'undefined') {
+    const result = localStorage.getItem('SideBarState');
+    if (result) {
+      return JSON.parse(result).SideBarState;
+    }
+  }
+  return false;
+};
+
+export const getSearchSideBarStateFromLocalStorage = () => {
+  if (typeof window !== 'undefined') {
+    const result = localStorage.getItem('SearchSideBarState');
+    if (result) {
+      return JSON.parse(result).SearchSideBarState;
+    }
+  }
+  return false;
+};

--- a/src/store/sidebar/atom.ts
+++ b/src/store/sidebar/atom.ts
@@ -1,11 +1,24 @@
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
 
-export const sideBarStateAtom = atom({
-  key: 'sideBarState',
-  default: true,
+const { persistAtom: persistSideBarAtom } = recoilPersist({
+  key: 'SideBarState',
+  storage: typeof window !== 'undefined' ? window.localStorage : undefined,
 });
 
-export const searchSideBarAtom = atom({
-  key: 'searchSideBarState',
+const { persistAtom: persistSearchSideBarAtom } = recoilPersist({
+  key: 'SearchSideBarState',
+  storage: typeof window !== 'undefined' ? window.localStorage : undefined,
+});
+
+export const sideBarStateAtom = atom<boolean>({
+  key: 'SideBarState',
   default: true,
+  effects: [persistSideBarAtom],
+});
+
+export const searchSideBarAtom = atom<boolean>({
+  key: 'SearchSideBarState',
+  default: true,
+  effects: [persistSearchSideBarAtom],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11064,6 +11064,11 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+recoil-persist@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/recoil-persist/-/recoil-persist-4.2.0.tgz#9fbb4a8c158cbb83ceb9dedf795aee24ed15395d"
+  integrity sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==
+
 recoil@^0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.4.tgz#d6508fa656d9c93e66fdf334e1f723a9e98801cf"


### PR DESCRIPTION
### 개요 

MOZI-244

### 작업 사항

- [x] recoil-persist를 사용해 사용자의 마지막 사이드바 상태 기억

### 기타

SSR에서 localStorage는 없기 때문에 분기해서 처리해야했습니다.
SSR환경에서 렌더링된 상태와 클라이언트 상태에서 렌더링된 상태가 다르면 에러가 발생합니다.

현재 `componentDidMount`시점에 로컬 스토리지를 읽어서 상태를 업데이트하도록 구성되어서 분명히 개선의 여지는 많지만 일단 기능을 완성했기 때문에 올리고 SSR을 처리할 수 있는 방법을 공부해보겠습니다.

또한 recoil-persist를 사용할 큰 이유는 없어서 recoil-persist를 제거하는 방향으로 나아가보겠습니다.