### PR TITLE
chore: merge 되는 경우만 CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,8 +3,6 @@ name: CD
 on:
   push:
     branches: [develop]
-  pull_request:
-    branches: [develop]
 
 jobs:
   CD:


### PR DESCRIPTION
- CD 하는데 시간이 너무 많이 걸리는데 실은 PR에서 CD를 돌릴 이유가 없습니다.
- Vercel 에서 빌드 체크를 해주니까 그래서 뺐습니다 :)