### PR TITLE
feat: map 페이지 로딩전에 임시 지도 이미지 표시

### DIFF
--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -8,12 +8,13 @@ import SearchSideBar from '@/components/map/SearchSideBar';
 import AppLayout from '@/components/common/AppLayout';
 import { useMapTodoList } from '@/hooks/apis/todo/useTodoListQuery';
 import { Todo } from '@/shared/types/todo';
+import Image from 'next/image';
 
 const Map: NextPageWithLayout = () => {
   const naverMapRef = useRef<HTMLDivElement>(null);
 
   const { data: todos } = useMapTodoList();
-  const { naverMap, createMarker, createPosition, setCoords } = useNaverMap();
+  const { naverMap, isMapLoading, createMarker, createPosition, setCoords } = useNaverMap();
 
   useEffect(() => {
     if (naverMap && todos) {
@@ -61,6 +62,8 @@ const Map: NextPageWithLayout = () => {
           // createMarker={createMarker}
           // createPosition={createPosition}
         />
+        {isMapLoading && <Image src="/assets/images/map.png" layout="fill" />}
+
         <MapLayout id="map" ref={naverMapRef} />
       </Container>
     </>


### PR DESCRIPTION
### 개요 

MOZI-282

지도가 로딩되기전에 로딩 스피너를 보여줄 수 있습니다. 
카카오 앱에서 지도를 처음에 사진을 먼저 보여주고 사용자가 지루하지 않게 만든 후에 지도가 실제 로딩되면 사용자가 인터랙션 가능한 지도를 보여주는 방법을 사용하는 것을 보았습니다.

### 작업 사항

- [x] 지도 로딩전에 임시 지도 이미지를 먼저 보여주기

### 변경후


https://user-images.githubusercontent.com/63354527/192938792-510c4a5f-1cc1-40fc-b119-310e5634e79c.mov




<!-- 변경 후 작동 화면 캡쳐 or 동영상 -->
