### PR TITLE
fix: TodoListItem 수정시 클릭은 포커스를 주지않음

### DIFF
--- a/src/components/common/TodoListItem/index.tsx
+++ b/src/components/common/TodoListItem/index.tsx
@@ -77,8 +77,10 @@ const TodoListItem: React.FC<TodoListItemProps> = ({
   }, [id, deleteTodo, isFocused]);
 
   const onClickHandler = useCallback(() => {
+    if (isDoubleClicked) return;
+
     setIsFocused(index);
-  }, [index, setIsFocused]);
+  }, [index, setIsFocused, isDoubleClicked]);
 
   const onDoubleClickHandler = useCallback((e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     if (document.getElementById('modal-root')?.contains(e.target as HTMLDivElement)) return;


### PR DESCRIPTION
### 개요  

기존에 투두를 수정중에 TodoListItem을 클릭하면 포커스가 그대로 되었는데 지금은 투두 수정중에 클릭해도 포커스 상태는 되지 않습니다.