### PR TITLE
feat: 달력 클릭시 해당 날짜, 이후의 Todo 보이기

### DIFF
--- a/src/components/upcoming/Calendar/index.tsx
+++ b/src/components/upcoming/Calendar/index.tsx
@@ -1,6 +1,17 @@
 import { useCallback } from 'react';
 
-import { Container, Header, DatesContainer, ArrowContainer, DaysContainer, Day, DateDiv } from './styles';
+import {
+  Container,
+  Header,
+  DatesContainer,
+  ArrowContainer,
+  DaysContainer,
+  Day,
+  DateDiv,
+  DateSpan,
+  TodosContainer,
+  TodoSpan,
+} from './styles';
 import { getYearMonth, getCalendarDates } from '@/shared/utils/date';
 import { NEXTARROW, PREVARROW } from '@/components/common/Figure';
 import { Todo } from '@/shared/types/todo';
@@ -15,7 +26,7 @@ interface CalendarProps {
   setNowDate: React.Dispatch<React.SetStateAction<Date>>;
 }
 
-const Calendar: React.FC<CalendarProps> = ({ nowDate, setNowDate }) => {
+const Calendar: React.FC<CalendarProps> = ({ todos, nowDate, setNowDate }) => {
   const onDateClickHandler = useCallback(
     (year: number, month: number, dateTime: number) => {
       setNowDate(new Date(year, month, dateTime, nowDate.getHours(), nowDate.getMinutes()));
@@ -47,6 +58,15 @@ const Calendar: React.FC<CalendarProps> = ({ nowDate, setNowDate }) => {
     );
   }, [nowDate]);
 
+  //같으면 true 다르면 false
+  const dateDiff = useCallback((todoDate: string | undefined, value: { year: number; month: number; date: number }) => {
+    if (!todoDate) return false;
+    const newDate = new Date(todoDate);
+    if (newDate.getFullYear() === value.year && newDate.getMonth() === value.month && newDate.getDate() === value.date)
+      return true;
+    else return false;
+  }, []);
+
   return (
     <Container>
       <Header>
@@ -70,31 +90,54 @@ const Calendar: React.FC<CalendarProps> = ({ nowDate, setNowDate }) => {
       <DatesContainer>
         {getCalendarDates(nowDate).map((value, index) => {
           const selected = nowDate.getMonth() === value.month && nowDate.getDate() === value.date;
+          const filteredTodos = todos.filter(
+            (todo) => dateDiff(todo.alarmDate, value) || dateDiff(todo.dueDate, value)
+          );
           const onClickHandler = () => {
             onDateClickHandler(value.year, value.month, value.date);
           };
           if (value.month != nowDate.getMonth())
             return (
-              <DateDiv key={index} selected={selected} color="#c2c2c2" onClick={onClickHandler}>
-                <span>{value.date}</span>
+              <DateDiv key={index} color="#c2c2c2" onClick={onClickHandler}>
+                <DateSpan selected={selected}>{value.date}</DateSpan>
+                <TodosContainer>
+                  {filteredTodos.map((todo) => (
+                    <TodoSpan>• {todo.title}</TodoSpan>
+                  ))}
+                </TodosContainer>
               </DateDiv>
             );
           else if (index % DAYS == SUN)
             return (
-              <DateDiv key={index} selected={selected} color="#FF6161" onClick={onClickHandler}>
-                <span>{value.date}</span>
+              <DateDiv key={index} color="#FF6161" onClick={onClickHandler}>
+                <DateSpan selected={selected}>{value.date}</DateSpan>
+                <TodosContainer>
+                  {filteredTodos.map((todo) => (
+                    <TodoSpan>• {todo.title}</TodoSpan>
+                  ))}
+                </TodosContainer>
               </DateDiv>
             );
           else if (index % DAYS == SAT)
             return (
-              <DateDiv key={index} selected={selected} color="#7380F6" onClick={onClickHandler}>
-                <span>{value.date}</span>
+              <DateDiv key={index} color="#7380F6" onClick={onClickHandler}>
+                <DateSpan selected={selected}>{value.date}</DateSpan>
+                <TodosContainer>
+                  {filteredTodos.map((todo) => (
+                    <TodoSpan>• {todo.title}</TodoSpan>
+                  ))}
+                </TodosContainer>
               </DateDiv>
             );
           else
             return (
-              <DateDiv key={index} selected={selected} onClick={onClickHandler}>
-                <span>{value.date}</span>
+              <DateDiv key={index} onClick={onClickHandler}>
+                <DateSpan selected={selected}>{value.date}</DateSpan>
+                <TodosContainer>
+                  {filteredTodos.map((todo) => (
+                    <TodoSpan>• {todo.title}</TodoSpan>
+                  ))}
+                </TodosContainer>
               </DateDiv>
             );
         })}

--- a/src/components/upcoming/Calendar/index.tsx
+++ b/src/components/upcoming/Calendar/index.tsx
@@ -1,16 +1,21 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import { Container, Header, DatesContainer, ArrowContainer, DaysContainer, Day, DateDiv } from './styles';
 import { getYearMonth, getCalendarDates } from '@/shared/utils/date';
 import { NEXTARROW, PREVARROW } from '@/components/common/Figure';
+import { Todo } from '@/shared/types/todo';
 
 const DAYS = 7;
 const SUN = 0;
 const SAT = 6;
 
-const Calendar: React.FC = () => {
-  const [nowDate, setNowDate] = useState(new Date());
+interface CalendarProps {
+  todos: Todo[];
+  nowDate: Date;
+  setNowDate: React.Dispatch<React.SetStateAction<Date>>;
+}
 
+const Calendar: React.FC<CalendarProps> = ({ nowDate, setNowDate }) => {
   const onDateClickHandler = useCallback(
     (year: number, month: number, dateTime: number) => {
       setNowDate(new Date(year, month, dateTime, nowDate.getHours(), nowDate.getMinutes()));

--- a/src/components/upcoming/Calendar/styles.tsx
+++ b/src/components/upcoming/Calendar/styles.tsx
@@ -67,7 +67,7 @@ export const DatesContainer = styled.div`
   padding: 2rem;
 `;
 
-export const DateDiv = styled.div<{ color?: string; selected: boolean }>`
+export const DateDiv = styled.div<{ color?: string }>`
   width: 13%;
   aspect-ratio: 1/0.9;
 
@@ -80,15 +80,30 @@ export const DateDiv = styled.div<{ color?: string; selected: boolean }>`
   border-bottom: 0.1rem solid #e8e8e8;
   margin-bottom: 1rem;
 
-  span {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  overflow: hidden;
+`;
 
-    border-radius: 2rem;
+export const DateSpan = styled.span<{ selected: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
-    width: 2rem;
-    height: 2rem;
-    background-color: ${({ selected }) => (selected ? '#ECECEC' : '#FFFFFF')};
-  }
+  border-radius: 2rem;
+
+  width: 2rem;
+  height: 2rem;
+  background-color: ${({ selected }) => (selected ? '#ECECEC' : '#FFFFFF')};
+`;
+
+export const TodosContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 0.5rem;
+`;
+
+export const TodoSpan = styled.span`
+  color: #735aff;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;

--- a/src/hooks/apis/todo/useTodoListQuery.ts
+++ b/src/hooks/apis/todo/useTodoListQuery.ts
@@ -78,6 +78,9 @@ export const useTodoListStatistics = () => {
 
 export const useUpcommingTodoList = () => {
   return useQuery(['todos'], todoService.getTodos, {
-    select: useCallback((todos: Todo[]) => todos.filter((todo) => todo.dueDate || todo.alarmDate), []),
+    select: useCallback(
+      (todos: Todo[]) => todos.filter((todo) => (todo.dueDate || todo.alarmDate) && !todo.deletedAt),
+      []
+    ),
   });
 };

--- a/src/hooks/apis/todo/useTodoListQuery.ts
+++ b/src/hooks/apis/todo/useTodoListQuery.ts
@@ -75,3 +75,9 @@ export const useTodoListStatistics = () => {
     initialData: { logbook: 0, trash: 0, inbox: 0, map: 0 },
   });
 };
+
+export const useUpcommingTodoList = () => {
+  return useQuery(['todos'], todoService.getTodos, {
+    select: useCallback((todos: Todo[]) => todos.filter((todo) => todo.dueDate || todo.alarmDate), []),
+  });
+};

--- a/src/pages/upcoming/index.tsx
+++ b/src/pages/upcoming/index.tsx
@@ -1,16 +1,33 @@
-import { ReactElement } from 'react';
-
+import { ReactElement, useState } from 'react';
 import { NextPageWithLayout } from '@/pages/_app';
+
 import AppLayout from '@/components/common/AppLayout';
 import styled from 'styled-components';
 import Title from '@/components/upcoming/Title';
 import Calendar from '@/components/upcoming/Calendar/index';
+import TodoList from '@/components/common/TodoList';
+import { useUpcommingTodoList } from '@/hooks/apis/todo/useTodoListQuery';
+import { useDeleteTodoMutation, useUpdateTodoMutation } from '@/hooks/apis/todo/useTodoMutation';
+import { dateToFormatString, dateDiff } from '@/shared/utils/date';
 
 const Upcoming: NextPageWithLayout = () => {
+  const [nowDate, setNowDate] = useState(new Date());
+  const { data: todos } = useUpcommingTodoList();
+  const { mutate: updateTodo } = useUpdateTodoMutation();
+  const { mutate: deleteTodo } = useDeleteTodoMutation();
+
   return (
     <Container>
       <Title />
-      <Calendar />
+      <Calendar todos={todos ? todos : []} nowDate={nowDate} setNowDate={setNowDate} />
+      <TodoWrapper>
+        <span>{dateToFormatString(nowDate)}</span>
+        <TodoList
+          todos={todos?.filter((todo) => dateDiff(todo.dueDate, nowDate) || dateDiff(todo.alarmDate, nowDate))}
+          updateTodo={updateTodo}
+          deleteTodo={deleteTodo}
+        />
+      </TodoWrapper>
     </Container>
   );
 };
@@ -25,6 +42,18 @@ const Container = styled.div`
   width: 100%;
 
   overflow: scroll;
+`;
+
+const TodoWrapper = styled.div`
+  height: auto;
+
+  span {
+    font-size: 1.5rem;
+    color: #2a2a2a;
+    font-weight: bold;
+
+    padding-inline: 3rem;
+  }
 `;
 
 export default Upcoming;

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -47,13 +47,13 @@ export const getDateToMin = (date: Date) => ('0' + date.getMinutes()).slice(SLIC
 
 export const dateDiff = (date1?: Date | string, date2?: Date | string) => {
   if (!date1 || !date2) return false;
-  date1 = new Date(date1);
-  date2 = new Date(date2);
+  const newDate1 = new Date(date1);
+  const newDate2 = new Date(date2);
 
   if (
-    date1.getFullYear() !== date1.getFullYear() ||
-    date1.getMonth() !== date2.getMonth() ||
-    date1.getDate() !== date2.getDate()
+    newDate1.getFullYear() !== newDate2.getFullYear() ||
+    newDate1.getMonth() !== newDate2.getMonth() ||
+    newDate1.getDate() !== newDate2.getDate()
   )
     return false;
 

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -44,3 +44,18 @@ export const getDateToHour = (date: Date) =>
   ('0' + ((date.getHours() + DAYHOURS) % HOURS || HOURS)).slice(SLICEMONTHLENGTH);
 
 export const getDateToMin = (date: Date) => ('0' + date.getMinutes()).slice(SLICEMONTHLENGTH);
+
+export const dateDiff = (date1?: Date | string, date2?: Date | string) => {
+  if (!date1 || !date2) return false;
+  date1 = new Date(date1);
+  date2 = new Date(date2);
+
+  if (
+    date1.getFullYear() !== date1.getFullYear() ||
+    date1.getMonth() !== date2.getMonth() ||
+    date1.getDate() !== date2.getDate()
+  )
+    return false;
+
+  return true;
+};

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -10,6 +10,13 @@ const DAYHOURS = 24;
 
 export const dateToString = (date: Date) => DAYS[date.getDay()] + ', ' + MONTHS[date.getMonth()] + ' ' + date.getDate();
 
+export const dateToFormatString = (date: Date) =>
+  date.getFullYear() +
+  '.' +
+  ('0' + (date.getMonth() + 1)).slice(SLICEMONTHLENGTH) +
+  '.' +
+  ('0' + date.getDate()).slice(SLICEMONTHLENGTH);
+
 export const getYearMonth = (date: Date) =>
   date.getFullYear() + '.' + ('0' + (date.getMonth() + 1)).slice(SLICEMONTHLENGTH);
 


### PR DESCRIPTION
### MOZI-310

달력에서 해당 날짜의 todo를 확인 할 수 있도록 구현하였습니다.

### 작업 사항

- 해당 날짜에 대한 todo 확인 기능
- 캘린더를 보면 간단한 todo title 확인 가능

### 변경후

<img width="639" alt="스크린샷 2022-10-16 오후 3 26 07" src="https://user-images.githubusercontent.com/51700274/196021488-690b879d-f745-44d2-9043-409a0bd17177.png">

<img width="577" alt="스크린샷 2022-10-16 오후 3 26 17" src="https://user-images.githubusercontent.com/51700274/196021497-e7d80610-39db-44a3-8f21-2f64bd4204b6.png">

### 기타

 <!-- 코드 리뷰시 중점적으로 봐줬으면 하는 부분 -->
