### PR TITLE
refactor: 최근 검색어 기능을 검색바 클릭시 보이도록 구현

### DIFF
--- a/src/components/map/SearchSideBar/RecentSearch/index.tsx
+++ b/src/components/map/SearchSideBar/RecentSearch/index.tsx
@@ -1,8 +1,9 @@
-import { Dispatch, SetStateAction, useId } from 'react';
+import { Dispatch, SetStateAction, useId, useRef } from 'react';
 
 import { Location, LocationSearchResult } from '@/shared/types/location';
 import { CANCEL } from '@/components/common/Figure';
 import { getItem, setItem } from '@/store/localStorage';
+import { useOnClickOutside } from '@/hooks/useOnClickOutside';
 import {
   Container,
   DeleteContainer,
@@ -16,10 +17,16 @@ interface RecentSearchProps {
   recentSearch: LocationSearchResult[];
   setRecentSearch: Dispatch<SetStateAction<LocationSearchResult[]>>;
   setCoords: Dispatch<SetStateAction<Location | undefined>>;
+  clearSearch: () => void;
 }
 
-const RecentSearch: React.FC<RecentSearchProps> = ({ recentSearch, setRecentSearch, setCoords }) => {
+const RecentSearch: React.FC<RecentSearchProps> = ({ recentSearch, setRecentSearch, setCoords, clearSearch }) => {
   const id = useId();
+  const recentSearchListRef = useRef<HTMLDivElement>(null);
+
+  useOnClickOutside(recentSearchListRef, () => {
+    clearSearch();
+  });
 
   const onDeleteRecentSearchKeyword = (deletedIndex: number) => {
     setRecentSearch((prev) => prev.filter((_, index) => id + index !== id + deletedIndex));
@@ -34,7 +41,7 @@ const RecentSearch: React.FC<RecentSearchProps> = ({ recentSearch, setRecentSear
   };
 
   return (
-    <Container>
+    <Container ref={recentSearchListRef}>
       <RecentSearchHeading>최근 검색어</RecentSearchHeading>
       <RecentSearchList>
         {recentSearch.map((recentSearchItem, index) => (

--- a/src/components/map/SearchSideBar/RecentSearch/styles.tsx
+++ b/src/components/map/SearchSideBar/RecentSearch/styles.tsx
@@ -6,6 +6,7 @@ export const Container = styled.div`
   margin: 0 auto;
 
   margin-top: 2.2rem;
+  padding-inline: 2rem;
 `;
 
 export const RecentSearchHeading = styled.h2`

--- a/src/components/map/SearchSideBar/index.tsx
+++ b/src/components/map/SearchSideBar/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, Dispatch, SetStateAction, useRef, useEffect, useLayoutEffect } from 'react';
+import React, { useState, useCallback, Dispatch, SetStateAction, useRef, useEffect, useLayoutEffect } from 'react';
 
 import RecentSearch from './RecentSearch';
 import { getLocationSearchResult } from '@/shared/utils/map';
@@ -66,7 +66,7 @@ const SearchSideBar: React.FC<SearchSideBarProps> = ({ setCoords }) => {
     setKeyword(e.target.value);
 
     if (e.target.value === '') {
-      clearSearch();
+      setSearchResult([]);
       return;
     }
 
@@ -100,37 +100,53 @@ const SearchSideBar: React.FC<SearchSideBarProps> = ({ setCoords }) => {
     setItem('RECENT_SEARCH', JSON.stringify([result, ...recentSearch].slice(0, 5)));
   };
 
+  const clickSearchBarHandler = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsSearching((oldState) => !oldState);
+  }, []);
+
   return (
     <Container isSearchBarOpen={isSearchBarOpen}>
       <SearchContainer isSeraching={isSearching}>
-        <SearchInput value={keyword} onChange={onChange} onKeyDown={onKeyDown} placeholder="검색어를 입력하세요." />
+        <SearchInput
+          value={keyword}
+          onChange={onChange}
+          onKeyDown={onKeyDown}
+          onClick={clickSearchBarHandler}
+          placeholder="검색어를 입력하세요."
+        />
         {isSearching && (
           <SearchResultContainer>
-            <SearchPlaceResultContainer ref={searchResultContainerRef} isSeraching={isSearching}>
-              <SearchPlaceResultHeading>장소</SearchPlaceResultHeading>
-              <SearchPlaceResultList>
-                {searchResult.map((result, index) => (
-                  <SearchPlaceResultItem
-                    key={index}
-                    onClick={() => {
-                      onChangePosition({ longitude: result.location[0], latitude: result.location[1] });
-                      onChangeRecentSearchResult(result);
-                    }}
-                  >
-                    <PlaceIcon>
-                      <SEARCHPLACE />
-                    </PlaceIcon>
-                    <PlaceName>{result.name}</PlaceName>
-                  </SearchPlaceResultItem>
-                ))}
-              </SearchPlaceResultList>
-            </SearchPlaceResultContainer>
+            {searchResult.length === 0 && (
+              <RecentSearch recentSearch={recentSearch} setRecentSearch={setRecentSearch} setCoords={setCoords} />
+            )}
+            {searchResult.length > 0 && (
+              <SearchPlaceResultContainer ref={searchResultContainerRef} isSeraching={isSearching}>
+                <SearchPlaceResultHeading>장소</SearchPlaceResultHeading>
+                <SearchPlaceResultList>
+                  {searchResult.map((result, index) => (
+                    <SearchPlaceResultItem
+                      key={index}
+                      onClick={() => {
+                        onChangePosition({ longitude: result.location[0], latitude: result.location[1] });
+                        onChangeRecentSearchResult(result);
+                      }}
+                    >
+                      <PlaceIcon>
+                        <SEARCHPLACE />
+                      </PlaceIcon>
+                      <PlaceName>{result.name}</PlaceName>
+                    </SearchPlaceResultItem>
+                  ))}
+                </SearchPlaceResultList>
+              </SearchPlaceResultContainer>
+            )}
+
             <SearchTodoContainer />
           </SearchResultContainer>
         )}
       </SearchContainer>
-
-      <RecentSearch recentSearch={recentSearch} setRecentSearch={setRecentSearch} setCoords={setCoords} />
 
       <SideBarToggleButton type="button" onClick={() => setIsSearchBarOpen((prev) => !prev)}>
         {isSearchBarOpen ? '닫기' : '열기'}

--- a/src/components/map/SearchSideBar/index.tsx
+++ b/src/components/map/SearchSideBar/index.tsx
@@ -55,7 +55,6 @@ const SearchSideBar: React.FC<SearchSideBarProps> = ({ setCoords }) => {
 
   const clearSearch = useCallback(() => {
     setIsSearching(false);
-    setSearchResult([]);
   }, []);
 
   const onKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -100,11 +99,9 @@ const SearchSideBar: React.FC<SearchSideBarProps> = ({ setCoords }) => {
     setItem('RECENT_SEARCH', JSON.stringify([result, ...recentSearch].slice(0, 5)));
   };
 
-  const clickSearchBarHandler = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsSearching((oldState) => !oldState);
-  }, []);
+  const clickSearchBarHandler = useCallback(() => {
+    setIsSearching(!isSearching);
+  }, [isSearching]);
 
   return (
     <Container isSearchBarOpen={isSearchBarOpen}>
@@ -119,7 +116,12 @@ const SearchSideBar: React.FC<SearchSideBarProps> = ({ setCoords }) => {
         {isSearching && (
           <SearchResultContainer>
             {searchResult.length === 0 && (
-              <RecentSearch recentSearch={recentSearch} setRecentSearch={setRecentSearch} setCoords={setCoords} />
+              <RecentSearch
+                recentSearch={recentSearch}
+                setRecentSearch={setRecentSearch}
+                setCoords={setCoords}
+                clearSearch={clearSearch}
+              />
             )}
             {searchResult.length > 0 && (
               <SearchPlaceResultContainer ref={searchResultContainerRef} isSeraching={isSearching}>


### PR DESCRIPTION
### MOZI-339

최근 검색어 기능을 검색바 쪽으로 옮기고 남은 자리에는 todolist item을 넣을 예정입니다.

### 작업 사항

- 최근 검색어 기능 검색바 클릭시 보이게 구현
- 최근 검색어 바깥쪽 클릭시 사라지도록 구현

### 변경후


https://user-images.githubusercontent.com/51700274/197765622-72131bc5-ad5f-493d-a0ac-87906a405fc5.mov



### 기타

 <!-- 코드 리뷰시 중점적으로 봐줬으면 하는 부분 -->
