### PR TITLE
refactor: useTodoListQuery 로직 통일 및 타입 추가

### DIFF
--- a/src/hooks/apis/todo/useTodoListQuery.ts
+++ b/src/hooks/apis/todo/useTodoListQuery.ts
@@ -9,7 +9,7 @@ import todoService from '@/services/apis/todo';
 import { ROUTES } from '@/shared/constants/routes';
 import { QUERY_TYPE_ERROR } from '@/shared/constants/dialog';
 
-export const useTodoListQuery = (page: string): UseQueryResult<Todo[], AxiosError> => {
+export const useTodoListQuery = (page: string): UseQueryResult<Todo[], AxiosError<ServerResponse>> => {
   switch (page) {
     case ROUTES.HOME:
       return useQuery(['todos'], todoService.getTodosFromIndexedDB, {
@@ -54,7 +54,7 @@ export const use_unsafe_todoListQuery = (): UseQueryResult<Todo[], AxiosError<Se
 
 export const useLogbookTodoList = () => {
   return useQuery(['todos'], todoService.getTodos, {
-    select: useCallback((todos: Todo[]) => todos.filter((todo) => todo.done && !todo.deletedAt), []),
+    select: (todos: Todo[]) => todos.filter((todo) => todo.done && !todo.deletedAt),
     onSuccess: (data: any) => {
       data;
     },
@@ -63,10 +63,7 @@ export const useLogbookTodoList = () => {
 
 export const useMapTodoList = () => {
   return useQuery(['todos'], todoService.getTodos, {
-    select: useCallback(
-      (todos: Todo[]) => todos.filter((todo) => todo.latitude && todo.longitude && !todo.deletedAt),
-      []
-    ),
+    select: (todos: Todo[]) => todos.filter((todo) => todo.latitude && todo.longitude && !todo.deletedAt),
   });
 };
 
@@ -101,9 +98,6 @@ export const useTodoListStatistics = () => {
 
 export const useUpcommingTodoList = () => {
   return useQuery(['todos'], todoService.getTodos, {
-    select: useCallback(
-      (todos: Todo[]) => todos.filter((todo) => (todo.dueDate || todo.alarmDate) && !todo.deletedAt),
-      []
-    ),
+    select: (todos: Todo[]) => todos.filter((todo) => (todo.dueDate || todo.alarmDate) && !todo.deletedAt),
   });
 };

--- a/src/hooks/apis/todo/useTodoListQuery.ts
+++ b/src/hooks/apis/todo/useTodoListQuery.ts
@@ -1,14 +1,15 @@
 import { useCallback } from 'react';
 import { AxiosError } from 'axios';
+import { ServerResponse } from 'http';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 
 import { queryClient } from '@/shared/utils/queryClient';
 import { Todo, TodoStatistics } from '@/shared/types/todo';
-import { ServerResponse } from '@/shared/types/common';
 import todoService from '@/services/apis/todo';
 import { ROUTES } from '@/shared/constants/routes';
+import { QUERY_TYPE_ERROR } from '@/shared/constants/dialog';
 
-export const use_unsafe_TodoListQuery = (page: string) => {
+export const useTodoListQuery = (page: string): UseQueryResult<Todo[], AxiosError> => {
   switch (page) {
     case ROUTES.HOME:
       return useQuery(['todos'], todoService.getTodosFromIndexedDB, {
@@ -31,9 +32,8 @@ export const use_unsafe_TodoListQuery = (page: string) => {
       return useQuery(['todos'], todoService.getTodosFromIndexedDB, {
         select: (todos: Todo[]) => todos.filter((todo) => todo.latitude && todo.longitude && !todo.deletedAt),
       });
-
     default:
-      throw new Error('적절한 QueryType이 아닙니다.');
+      throw new Error(QUERY_TYPE_ERROR);
   }
 };
 
@@ -51,12 +51,6 @@ export const use_unsafe_todoListQuery = (): UseQueryResult<Todo[], AxiosError<Se
       []
     ),
   });
-
-export const useTodoListQuery = (): UseQueryResult<Todo[], AxiosError<ServerResponse>> => {
-  return useQuery(['todos'], todoService.getTodos, {
-    select: useCallback((todos: Todo[]) => todos.filter((todo) => !todo.deletedAt && !todo.done), []),
-  });
-};
 
 export const useLogbookTodoList = () => {
   return useQuery(['todos'], todoService.getTodos, {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,7 @@ import { NextPageWithLayout } from '@/pages/_app';
 import TodoList from '@/components/common/TodoList/DraggableTodoList';
 import { AppLayout, Title, Footer, Header, DropPlaceholder } from '@/components/common';
 import { INBOX, TRASH } from '@/components/common/Figure';
-import { use_unsafe_todoListQuery } from '@/hooks/apis/todo/useTodoListQuery';
+import { useTodoListQuery } from '@/hooks/apis/todo/useTodoListQuery';
 import {
   use_unsafe_createTodoMutation,
   use_unsafe_deleteTodoMutation,
@@ -15,17 +15,16 @@ import {
 import { queryClient } from '@/shared/utils/queryClient';
 import { theme } from '@/styles/theme';
 import { Todo } from '@/shared/types/todo';
+import { ROUTES } from '@/shared/constants/routes';
 
 const Home: NextPageWithLayout = () => {
   const [isDragging, setIsDragging] = useState(false);
-  const { data: todos } = use_unsafe_todoListQuery();
+  const { data: todos } = useTodoListQuery(ROUTES.HOME);
   const { mutate: createTodo } = use_unsafe_createTodoMutation();
   const { mutate: updateTodo } = use_unsafe_updateTodoMutation();
   const { mutate: deleteTodo } = use_unsafe_deleteTodoMutation();
 
-  const onDragStart = useCallback(() => {
-    setIsDragging(true);
-  }, []);
+  const onDragStart = () => setIsDragging(true);
 
   const onClickHandler = useCallback(() => {
     createTodo({});

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -16,7 +16,8 @@ import { AppLayout, Header } from '@/components/common';
 import { Todo } from '@/shared/types/todo';
 import { Location } from '@/shared/types/location';
 import { useNaverMap } from '@/hooks/useNaverMap';
-import { useMapTodoList } from '@/hooks/apis/todo/useTodoListQuery';
+import { useTodoListQuery } from '@/hooks/apis/todo/useTodoListQuery';
+import { ROUTES } from '@/shared/constants/routes';
 
 const Map: NextPageWithLayout = () => {
   const naverMapRef = useRef<HTMLDivElement>(null);
@@ -26,7 +27,7 @@ const Map: NextPageWithLayout = () => {
   const [markers, setMarkers] = useState<Array<naver.maps.Marker>>([]);
   const { naverMap, isMapLoading, createMarker, createPosition, setCoords } = useNaverMap();
 
-  const { data: todos } = useMapTodoList();
+  const { data: todos } = useTodoListQuery(ROUTES.MAP);
   const { mutate: createTodo } = use_unsafe_createTodoMutation();
   const { mutate: updateTodo } = use_unsafe_updateTodoMutation();
   const { mutate: deleteTodo } = use_unsafe_deleteTodoMutation();

--- a/src/pages/trash/index.tsx
+++ b/src/pages/trash/index.tsx
@@ -6,7 +6,7 @@ import { DragDropContext, Droppable, DropResult } from 'react-beautiful-dnd';
 
 import { NextPageWithLayout } from '@/pages/_app';
 import { queryClient } from '@/shared/utils/queryClient';
-import { useSoftDeletedTodoList } from '@/hooks/apis/todo/useTodoListQuery';
+import { useTodoListQuery } from '@/hooks/apis/todo/useTodoListQuery';
 import { Header, Spinner, Title, AppLayout, Footer, DropPlaceholder } from '@/components/common';
 import TodoList from '@/components/common/TodoList/DraggableTodoList';
 import { theme } from '@/styles/theme';
@@ -17,11 +17,12 @@ import {
   use_unsafe_createTodoMutation,
   use_unsafe_updateTodoMutation,
 } from '@/hooks/apis/todo/useTodoMutation';
+import { ROUTES } from '@/shared/constants/routes';
 
 const Trash: NextPageWithLayout = () => {
   const [isDragging, setIsDragging] = useState(false);
+  const { data: todos, isLoading } = useTodoListQuery(ROUTES.TRASH);
   const { mutate: createTodo } = use_unsafe_createTodoMutation();
-  const { data: todos, isLoading } = useSoftDeletedTodoList();
   const { mutate: forceDeleteTodo } = useForceDeleteTodoMutation();
   const { mutate: updateTodo } = use_unsafe_updateTodoMutation();
   const { mutate: deleteAllTodos } = useDeleteAllTodosMutation();

--- a/src/pages/upcoming/index.tsx
+++ b/src/pages/upcoming/index.tsx
@@ -6,13 +6,14 @@ import { NextPageWithLayout } from '@/pages/_app';
 import { AppLayout, Header, Title, TodoList } from '@/components/common';
 import { UPCOMING } from '@/components/common/Figure';
 import Calendar from '@/components/upcoming/Calendar';
-import { useUpcommingTodoList } from '@/hooks/apis/todo/useTodoListQuery';
+import { useTodoListQuery } from '@/hooks/apis/todo/useTodoListQuery';
 import { use_unsafe_deleteTodoMutation, use_unsafe_updateTodoMutation } from '@/hooks/apis/todo/useTodoMutation';
 import { dateToFormatString, dateDiff } from '@/shared/utils/date';
+import { ROUTES } from '@/shared/constants/routes';
 
 const Upcoming: NextPageWithLayout = () => {
   const [nowDate, setNowDate] = useState(new Date());
-  const { data: todos } = useUpcommingTodoList();
+  const { data: todos } = useTodoListQuery(ROUTES.UPCOMING);
   const { mutate: updateTodo } = use_unsafe_updateTodoMutation();
   const { mutate: deleteTodo } = use_unsafe_deleteTodoMutation();
 

--- a/src/shared/constants/dialog.ts
+++ b/src/shared/constants/dialog.ts
@@ -7,3 +7,4 @@ export const TODO_DELETE_FAILED = '할 일을 삭제하는데 실패했습니다
 export const SERVICE_WORKER_REGISTRATION_ERROR = '웹 사이트를 로드하는데 실패했습니다. 새로고침을 해주세요.' as const;
 export const TODO_CREATED = 'Inbox에 할 일을 추가했습니다' as const;
 export const GET_LOCATION_ERROR = '위치 정보를 가져오는데 실패했습니다' as const;
+export const QUERY_TYPE_ERROR = '적절한 QueryType이 아닙니다' as const;

--- a/src/shared/types/common.ts
+++ b/src/shared/types/common.ts
@@ -1,7 +1,0 @@
-// ! TODO 우선 서버에서 어떻게 응답을 줄지 명확하게 합의되지 않은 상태이므로 모두 Optional로 처리
-export interface ServerResponse {
-  code?: number;
-  data?: null;
-  msg?: string;
-  success?: boolean;
-}

--- a/src/shared/types/todo.ts
+++ b/src/shared/types/todo.ts
@@ -21,7 +21,7 @@ export interface Todo {
   updated?: boolean;
   deleted?: boolean;
 
-  offline?: boolean;
+  offline?: 'created' | 'updated' | 'deleted' | 'forceDeleted';
   offlineDeleted?: boolean;
   offlineForceDeleted?: boolean;
   forceDeleted?: boolean;

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -89,8 +89,6 @@ self.addEventListener('sync', async (event: SyncEvent) => {
           return Promise.reject();
         }
 
-        // console.log('실행이안되는것같은데?');
-
         // const temp = await Promise.all(
         //   todos.map((todo: any) => {
         //     if (todo.offline) {
@@ -126,9 +124,7 @@ self.addEventListener('sync', async (event: SyncEvent) => {
         //         Authorization: `Bearer ${token}`,
         //       },
         //     });
-        //     console.log('fetch 후');
         //   }
-        //   console.log('완전 끝');
         // });
       })()
     );
@@ -136,7 +132,6 @@ self.addEventListener('sync', async (event: SyncEvent) => {
 });
 
 // self.addEventListener('sync', async (event: SyncEvent) => {
-//   console.log('sync 이벤트 발생');
 //   if (event.tag === SYNC_TODOS) {
 //     console.log('service worker sync-todo event');
 //     event.waitUntil(
@@ -176,14 +171,11 @@ self.addEventListener('sync', async (event: SyncEvent) => {
 //             });
 //           }
 //         });
-
-//         //     console.log(todo.id, 'updatedtododi');
 //         //     // axios.patch(`https://mozi-server.com/api/v1/todos/${todo.id}`, {
 //         //     //   ...todo,
 //         //     // });
 //         //     // a();
 
-//         //     console.log('업데이트');
 //         //     // await fetcher('patch', `/todos/${todo.id}`, {
 //         //     //   title: todo.title,
 //         //     //   longitude: todo.location?.coordinates[0],
@@ -196,8 +188,6 @@ self.addEventListener('sync', async (event: SyncEvent) => {
 //         // });
 //       })()
 //     );
-
-//     console.log('sync 완료');
 //   }
 // });
 
@@ -213,7 +203,6 @@ const getSub = async () => {
 };
 
 self.addEventListener('message', (event) => {
-  // 웹 페이지로부터 토큰을 받음
   if (event.data.type === TOKEN) {
     token = event.data.token;
     return;


### PR DESCRIPTION
### 개요 

react-query type, 여러개의 query 한개로 변환

### 작업 사항

- [x] Switch문과 Route 변수를 활용해 각 페이지에서 사용되는 Query를 통일
- [x] useTodoListQuery에 타입 추가

