### PR TITLE
fix: 장소 검색 성능 향상

### DIFF
--- a/src/components/map/SearchSideBar/index.tsx
+++ b/src/components/map/SearchSideBar/index.tsx
@@ -79,9 +79,9 @@ const SearchSideBar: React.FC<SearchSideBarProps> = ({ setCoords, todos, updateT
     const { coords } = await getCurrentPosition();
 
     const result = await getLocationSearchResult({
-      keyword: e.target.value,
-      latitude: coords.latitude,
       longitude: coords.longitude,
+      latitude: coords.latitude,
+      keyword: e.target.value,
     });
 
     if (e.target.value.length > 0) {

--- a/src/services/apis/location.ts
+++ b/src/services/apis/location.ts
@@ -1,14 +1,18 @@
 import fetcher from '@/shared/utils/fetcher';
 
 export interface GetSearchResultParams {
-  keyword: string;
-  latitude: number;
   longitude: number;
+  latitude: number;
+  keyword: string;
 }
 
 const locationService = {
-  getsearchResult: async ({ keyword, latitude, longitude }: GetSearchResultParams) =>
-    await fetcher('post', '/location/nearby', { keyword, latitude, longitude }),
+  getsearchResult: async ({ longitude, latitude, keyword }: GetSearchResultParams) =>
+    await fetcher('get', `/location?keyword=${keyword}&longitude=${longitude}&latitude=${latitude}`, {
+      longitude,
+      latitude,
+      keyword,
+    }),
 };
 
 export default locationService;

--- a/src/shared/utils/map.ts
+++ b/src/shared/utils/map.ts
@@ -1,7 +1,7 @@
 import locationService, { GetSearchResultParams } from '@/services/apis/location';
 
-export const getLocationSearchResult = async ({ keyword, latitude, longitude }: GetSearchResultParams) => {
-  const searchResult = await locationService.getsearchResult({ keyword, latitude, longitude });
+export const getLocationSearchResult = async ({ longitude, latitude, keyword }: GetSearchResultParams) => {
+  const searchResult = await locationService.getsearchResult({ longitude, latitude, keyword });
   return searchResult;
 };
 


### PR DESCRIPTION
### 개요

기존의 장소 검색 기능의 API End point는 `POST /location/nearby` 였습니다.
이를 `GET /location?keyword={}&longitude={}&latitude={}`로 바꿨습니다.
이에 맞춰서 호출하는 부분도 바꿔줬습니다.

### 작업 사항

- location search API 호출 방법 변경

### 변경후
![image](https://user-images.githubusercontent.com/44183313/200297817-3429bcd0-5f04-4974-9853-23ea329bb675.png)

`POST` 대신에 `GET`을 사용하니 아주 빨라졌습니다!
