### PR TITLE
chore: remove cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,8 @@
 name: CD
 
-on:
-  push:
-    branches: [develop]
+# on:
+#   push:
+#     branches: [develop]
 
 jobs:
   CD:


### PR DESCRIPTION
aws 지원 중지로 인한 cd 제거